### PR TITLE
options.list is undefined. Causes process to crash.

### DIFF
--- a/lib/big-xml.js
+++ b/lib/big-xml.js
@@ -11,7 +11,7 @@ exports.createReader = function(filename, recordRegEx, options) {
 function BigXmlReader(filename, recordRegEx, options) {
   var self = this;
   
-  options.lists = options.lists || [];
+  options = options || [];
   options.gzip = options.gzip || false;
   
   var parser = new expat.Parser('UTF-8');


### PR DESCRIPTION
```options.list``` is undefined. Causes server to crash. Removing the ```.list``` part seems to fix the problem.

Error from console:

/var/www/bogprisbot/node_modules/big-xml-streamer/lib/big-xml.js:14
  options.lists = options.lists || [];
                         ^

TypeError: Cannot read property 'lists' of undefined
    at new BigXmlReader (/var/www/bogprisbot/node_modules/big-xml-streamer/lib/big-xml.js:14:26)
    at Object.exports.createReader (/var/www/bogprisbot/node_modules/big-xml-streamer/lib/big-xml.js:8:10)